### PR TITLE
Resolves gh-18: Only outputs keypoints when they meet the min score.

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,6 @@
 const {contextBridge, ipcRenderer} = require("electron");
 
 contextBridge.exposeInMainWorld("osc", {
-    send: (poses, ip, port) => ipcRenderer.invoke("send", poses, ip, port)
+    send: (poses, minimumScore, ip, port) => ipcRenderer.invoke(
+        "send", poses, minimumScore, ip, port)
 });

--- a/src/renderer/detect.js
+++ b/src/renderer/detect.js
@@ -53,7 +53,7 @@ async function detectPoses() {
     poseInfoRenderer.render(poses);
     videoPoseRenderer.minimumScore = minimumScoreField.value;
     videoPoseRenderer.render(poses);
-    osc.send(poses, ipField.value, portField.value);
+    osc.send(poses, minimumScoreField.value, ipField.value, portField.value);
     requestAnimationFrame(detectPoses);
 }
 


### PR DESCRIPTION
This implementation uses NaN as the "not recognized" value, but we may decide to change this later when keypoint values have been properly normalized between 0.0 and 1.0 (for x and y values) and between -1.0 and 1.0 (for the z axis).

Also, it's likely that as other transformations of the keypoint set are needed, they should happen earlier, in the renderer process.