### PR TITLE
Resolves gh-5, resolves gh-25: Signs and notarizes for macOS.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: Package Electron app
         run: |
           npm install
-          npm run create-release-artifacts
+          npm run package-all

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+omit=optional

--- a/build-scripts/notarize-macos.sh
+++ b/build-scripts/notarize-macos.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir -p dist/notarization
+
+# Zip up the application for the notarization server.
+echo "Preparing application for notarization..."
+ditto -c -k --keepParent dist/$1/MovementOSC.app dist/notarization/$2
+
+# Submit it for notarization.
+echo "Submitting application for notarization..."
+xcrun notarytool submit dist/notarization/$2 --keychain-profile "$APPLE_NOTARIZATION_KEYCHAIN_PROFILE" --wait && xcrun stapler staple dist/$1/MovementOSC.app && xcrun stapler validate dist/$1/MovementOSC.app

--- a/build-scripts/prepare-release-artifacts.sh
+++ b/build-scripts/prepare-release-artifacts.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+mkdir -p dist/release
+
+zip -r dist/release/MovementOSC-$1-win32-x64.zip dist/MovementOSC-win32-x64 -x '*.DS_Store' -x '__MACOSX'
+
+zip -r dist/release/MovementOSC-$1-linux-x64.zip dist/MovementOSC-linux-x64 -x '*.DS_Store' -x '__MACOSX'
+
+mkdir -p dist/release/MovementOSC-$1-darwin-arm64/
+mv dist/MovementOSC-darwin-arm64/MovementOSC.app dist/release/MovementOSC-$1-darwin-arm64/
+
+mkdir -p dist/release/MovementOSC-$1-darwin-x64/
+mv dist/MovementOSC-darwin-x64/MovementOSC.app dist/release/MovementOSC-$1-darwin-x64/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "movement-osc",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "movement-osc",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "license": "MIT",
             "dependencies": {
                 "@mediapipe/pose": "0.5.1675469404",
@@ -901,9 +901,9 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-            "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "movement-osc",
     "productName": "MovementOSC",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "contributors": [
         {
             "name": "Kinetic Light",
@@ -28,13 +28,22 @@
         "electron": "33.2.0",
         "@electron/packager": "18.3.6"
     },
+    "config": {
+        "copyright": "Copyright 2024 Lichen Community Systems Worker Cooperative Canada and Kinetic Light",
+        "bundleId": "coop.lichen.MovementOSC",
+        "categoryType": "public.app-category.video"
+    },
     "scripts": {
         "start": "node_modules/.bin/electron .",
-        "package-mac-intel": "node_modules/.bin/electron-packager ./ --platform=darwin --arch=x64 --out=./dist --overwrite",
-        "package-mac-arm": "node_modules/.bin/electron-packager ./ --platform=darwin --arch=arm64 --out=./dist --overwrite",
-        "package-win-x64": "node_modules/.bin/electron-packager ./ --platform=win32 --arch=x64 --out=./dist --overwrite",
-        "package-linux-x64": "node_modules/.bin/electron-packager ./ --platform=linux --arch=x64 --out=./dist --overwrite",
-        "package-all": "rm -rf dist/* && npm run package-mac-arm && npm run package-mac-intel && npm run package-win-x64 && npm run package-linux-x64",
-        "create-release-artifacts": "npm run package-all && zip -r dist/MovementOSC-darwin-x64.zip dist/MovementOSC-darwin-x64 && zip -r dist/MovementOSC-darwin-arm64.zip dist/MovementOSC-darwin-arm64  && zip -r dist/MovementOSC-win32-x64.zip dist/MovementOSC-win32-x64 -x '*.DS_Store' -x '__MACOSX' && zip -r dist/MovementOSC-linux-x64.zip dist/MovementOSC-linux-x64 -x '*.DS_Store' -x '__MACOSX'"
+        "package-mac-intel": "node_modules/.bin/electron-packager ./ --platform=darwin --arch=x64 --out=./dist --overwrite --app-copyright=\"$npm_package_config_copyright\" --app-bundle-id=\"$npm_package_config_bundleID\" --app-category-type=\"$npm_package_config_categoryType\" --no-junk --osx-sign",
+        "package-mac-arm": "node_modules/.bin/electron-packager ./ --platform=darwin --arch=arm64 --out=./dist --overwrite --app-copyright=\"$npm_package_config_copyright\" --app-bundle-id=\"$npm_package_config_bundleID\" --app-category-type=\"$npm_package_config_categoryType\" --no-junk --osx-sign",
+        "package-win-x64": "node_modules/.bin/electron-packager ./ --platform=win32 --arch=x64 --out=./dist --overwrite --app-copyright=\"$npm_package_config_copyright\" --no-junk",
+        "package-linux-x64": "node_modules/.bin/electron-packager ./ --platform=linux --arch=x64 --out=./dist --overwrite --app-copyright=\"$npm_package_config_copyright\" --no-junk",
+        "package-all": "npm run package-mac-arm && npm run package-mac-intel && npm run package-win-x64 && npm run package-linux-x64",
+        "notarize-mac-arm": "build-scripts/notarize-macos.sh \"MovementOSC-darwin-arm64\" \"MovementOSC-macOS-arm.zip\"",
+        "notarize-mac-intel": "build-scripts/notarize-macos.sh \"MovementOSC-darwin-x64\" \"MovementOSC-macOS-intel.zip\"",
+        "notarize-mac-all": "npm run notarize-mac-arm && npm run notarize-mac-intel",
+        "prepare-release-artifacts": "build-scripts/prepare-release-artifacts.sh $npm_package_version",
+        "prepare-release": "npm run package-all && npm run notarize-mac-all && npm run prepare-release-artifacts"
     }
 }


### PR DESCRIPTION
This PR includes significantly refactored build scripts with support for signing and notarizing the macOS builds of MovementOSC. Also bumps the version to 0.0.7 in preparation for a new release.