### PR TITLE
Fixes gh-30: Removes trailing slash from OSC addresses.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "movement-osc",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "movement-osc",
-            "version": "0.0.8",
+            "version": "0.0.9",
             "license": "MIT",
             "dependencies": {
                 "@mediapipe/pose": "0.5.1675469404",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "movement-osc",
     "productName": "MovementOSC",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "contributors": [
         {
             "name": "Kinetic Light",

--- a/src/main/osc-format-sender.js
+++ b/src/main/osc-format-sender.js
@@ -146,7 +146,7 @@ class OSCFormatSender {
         };
 
         for (let i = 0; i < poses.length; i++) {
-            let posePrefix = `/pose/${i}/`;
+            let posePrefix = `/pose/${i}`;
             let pose = poses[i];
             let oscPose = {
                 address: posePrefix,


### PR DESCRIPTION
This PR also bumps the version number to 0.0.9.