### PR TITLE
Fixes gh-32: Binds UDPPort to all interfaces

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const OSCFormatSender = require("./main/osc-format-sender.js");
 const NOT_RECOGNIZED = NaN;
 
 let udpPort = new osc.UDPPort({
+    localAddress: "0.0.0.0",
     remotePort: 57122,
     metadata: true
 });

--- a/src/main/osc-format-sender.js
+++ b/src/main/osc-format-sender.js
@@ -74,6 +74,10 @@ class OSCFormatSender {
         }
     }
 
+    sendBundledMessagePerAxisFormat(poses, ip, port) {
+
+    }
+
     /**
      * Sends pose data as an OSC bundle containing message packets
      * for each pose. Keypoints are represented as 33 arrays containing

--- a/src/main/osc-format-sender.js
+++ b/src/main/osc-format-sender.js
@@ -74,10 +74,6 @@ class OSCFormatSender {
         }
     }
 
-    sendBundledMessagePerAxisFormat(poses, ip, port) {
-
-    }
-
     /**
      * Sends pose data as an OSC bundle containing message packets
      * for each pose. Keypoints are represented as 33 arrays containing

--- a/src/test/node-osc-listener.js
+++ b/src/test/node-osc-listener.js
@@ -3,7 +3,11 @@
 const osc = require("osc");
 const util = require('node:util');
 
-let udpPort = new osc.UDPPort({localPort: 7500});
+let udpPort = new osc.UDPPort({
+    localAddress: "0.0.0.0",
+    localPort: 7500
+});
+
 udpPort.on("osc", (packet) => {
     console.log(util.inspect(packet, {
         depth: 100


### PR DESCRIPTION
This PR fixes the issue where MovementOSC is only able to send data to the loopback interface.